### PR TITLE
Support command groups in help messages.

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -16,7 +16,7 @@ test:
 
 # TODO: add python 3.3 and 3.4 testing
 .PHONY: testall
-testall: test26 test27 test33 test34
+testall: test26 test27 test33 test34 test35
 .PHONY: test26
 test26:
 	@echo "# Test with python 2.6"
@@ -37,6 +37,11 @@ test34:
 	@echo "# Test with python 3.4"
 	@python3.4 --version
 	make test PYTHON=python3.4
+.PHONY: test35
+test35:
+	@echo "# Test with python 3.5"
+	@python3.5 --version
+	make test PYTHON=python3.5
 
 
 # Ensure CHANGES.md and package.json have the same version.

--- a/Makefile
+++ b/Makefile
@@ -1,4 +1,4 @@
-
+SHELL := /bin/bash
 PYTHON ?= python
 
 

--- a/lib/cmdln.py
+++ b/lib/cmdln.py
@@ -1342,7 +1342,6 @@ def _summarize_doc(doc, length=60):
     >>> _summarize_doc("this function does this\n\nand that")
     'this function does this'
     """
-    import re
     if doc is None:
         return ""
     assert length > 3, "length <= 3 is absurdly short for a doc summary"

--- a/lib/cmdln.py
+++ b/lib/cmdln.py
@@ -41,17 +41,13 @@ from __future__ import print_function
 __version_info__ = (2, 0, 1)
 __version__ = '.'.join(map(str, __version_info__))
 
-
 import os
 import sys
 import re
 import cmd
 import optparse
 from pprint import pprint
-import sys
 import datetime
-
-
 
 #---- globals
 
@@ -159,7 +155,6 @@ class RawCmdln(cmd.Cmd):
         error output. This is to provide least surprise for users used
         to only the 'stdin' and 'stdout' options with cmd.Cmd.
         """
-        import sys
         if self.name is None:
             self.name = os.path.basename(sys.argv[0])
         if self.prompt is None:
@@ -240,7 +235,6 @@ class RawCmdln(cmd.Cmd):
         """
 
         if argv is None:
-            import sys
             argv = sys.argv
         else:
             argv = argv[:] # don't modify caller's list
@@ -310,7 +304,6 @@ class RawCmdln(cmd.Cmd):
             #XXX What is the proper encoding to use here? 'utf-8' seems
             #    to work better than "getdefaultencoding" (usually
             #    'ascii'), on OS X at least.
-            #import sys
             #return s.encode(sys.getdefaultencoding(), "replace")
             return s.encode("utf-8", "replace")
 
@@ -414,7 +407,6 @@ class RawCmdln(cmd.Cmd):
         opposed to programmer error in the design of the script using
         cmdln.py).
         """
-        import sys
         type, exc, traceback = sys.exc_info()
         if isinstance(exc, CmdlnUserError):
             msg = "%s %s: %s\nTry '%s help %s' for info.\n"\
@@ -1158,7 +1150,6 @@ class Cmdln(RawCmdln):
                 # Some TypeError's are user errors because of incorrect number
                 # of arguments. Raise CmdlnUserError for these with a suitably
                 # massaged error message.
-                import sys
                 tb = sys.exc_info()[2] # the traceback object
                 if tb.tb_next is not None:
                     # If the traceback is more than one level deep, then the

--- a/lib/cmdln.py
+++ b/lib/cmdln.py
@@ -718,7 +718,6 @@ class RawCmdln(cmd.Cmd):
     def _gen_names_and_attrs(self):
         # Inheritance says we have to look in class and
         # base classes; order is not important.
-        names = []
         classes = [self.__class__]
         while classes:
             aclass = classes.pop(0)
@@ -1536,7 +1535,6 @@ def _dedentlines(lines, tabsize=8, skip_first_line=False):
     if DEBUG:
         print("dedent: dedent(..., tabsize=%d, skip_first_line=%r)"\
               % (tabsize, skip_first_line))
-    indents = []
     margin = None
     for i, line in enumerate(lines):
         if i == 0 and skip_first_line: continue

--- a/test/cmdln_help_groups.py
+++ b/test/cmdln_help_groups.py
@@ -1,0 +1,113 @@
+#!/usr/bin/env python
+
+"""
+    $ python cmdln_help_groups.py foo
+    hello from foo
+    $ python cmdln_help_groups.py fuz
+    hello from fuz
+    $ python cmdln_help_groups.py bar
+    hello from bar
+    $ python cmdln_help_groups.py barbababa
+    hello from bar
+    $ python cmdln_help_groups.py buz
+    hello from buz
+    $ python cmdln_help_groups.py baz
+    hello from baz
+    $ python cmdln_help_groups.py fez
+    hello from fez
+    $ python cmdln_help_groups.py buz
+    hello from buz
+
+    $ python cmdln_help_groups.py help
+    Usage:
+        cmdln_help_groups.py COMMAND [ARGS...]
+        cmdln_help_groups.py help [COMMAND]
+    <BLANKLINE>
+    Options:
+        -h, --help  show this help message and exit
+    <BLANKLINE>
+    Commands:
+        foo             shazam!
+        fuz (fuuzbaba)  zizing!
+        help (?)        give detailed help on a specific sub-command
+        help-all        display alternative help message
+        help-foobar     display alternative help message
+
+    $ python cmdln_help_groups.py help-all
+    Usage:
+        cmdln_help_groups.py COMMAND [ARGS...]
+        cmdln_help_groups.py help [COMMAND]
+    <BLANKLINE>
+    Options:
+        -h, --help  show this help message and exit
+    <BLANKLINE>
+    Commands:
+        bar (barbababa)  whopee!
+        fez              pojoing!
+        foo              shazam!
+        fuz (fuuzbaba)   zizing!
+        help (?)         give detailed help on a specific sub-command
+        help-all         display alternative help message
+        help-foobar      display alternative help message
+
+    $ python cmdln_help_groups.py help-foobar
+    Usage:
+        cmdln_help_groups.py COMMAND [ARGS...]
+        cmdln_help_groups.py help [COMMAND]
+    <BLANKLINE>
+    Options:
+        -h, --help  show this help message and exit
+    <BLANKLINE>
+    Commands:
+        buz             buzzzzz!
+        fez             pojoing!
+        foo             shazam!
+        fuz (fuuzbaba)  zizing!
+        help (?)        give detailed help on a specific sub-command
+        help-all        display alternative help message
+        help-foobar     display alternative help message
+
+"""
+
+import sys
+import cmdln
+
+class Shell(cmdln.Cmdln):
+    def do_foo(self, argv):
+        "shazam!"
+        print("hello from foo")
+
+    @cmdln.alias("fuuzbaba")
+    def do_fuz(self, argv):
+        "zizing!"
+        print("hello from fuz")
+
+    @cmdln.alias("barbababa")
+    @cmdln.group("all")
+    def do_bar(self, argv):
+        "whopee!"
+        print("hello from bar")
+
+    @cmdln.group("all")
+    def do_buz(self, argv):
+        "kaboom!"
+        print("hello from buz")
+
+    def _do_baz(self, argv):
+        "kazinga!"
+        print("hello from baz")
+
+    @cmdln.group("all", "foobar")
+    def do_fez(self, argv):
+        "pojoing!"
+        print("hello from fez")
+
+    @cmdln.group("foobar")
+    def do_buz(self, argv):
+        "buzzzzz!"
+        print("hello from buz")
+
+if __name__ == "__main__":
+    shell = Shell()
+    retval = shell.main(loop=cmdln.LOOP_NEVER) # don't want a command loop
+    sys.exit(retval)

--- a/test/cmdln_man_page_generation.py
+++ b/test/cmdln_man_page_generation.py
@@ -1,0 +1,59 @@
+#!/usr/bin/env python
+
+"""
+    $ python cmdln_man_page_generation.py
+"""
+
+import sys
+import cmdln
+
+class Shell(cmdln.Cmdln):
+    def get_optparser(self):
+        """ the parser"""
+
+        optparser = cmdln.CmdlnOptionParser(self, version="1.2.3")
+        optparser.add_option("--foobar", action="store_true",
+                help="dskjdsfjkdsfkjdsfj kjdfs dsfkj kj dsfkjdfs dfkj dsfkjdf sf dskjkdjs f!")
+        return optparser
+
+    @cmdln.option("-k", "--keeekkeke", help="This ksdl fslkd dsflkdfslksd flkdsf lksdf sdlk sdflkdsf lksdis the kekeke.", action="store_true")
+    def do_foo(self, argv):
+        """shazam!
+
+        ${cmd_option_list}
+        """
+        print("hello from foo")
+
+    @cmdln.alias("fuuzbaba")
+    def do_fuz(self, argv):
+        "zizing!"
+        print("hello from fuz")
+
+    @cmdln.alias("barbababa")
+    @cmdln.group("all")
+    def do_bar(self, argv):
+        "whopee!"
+        print("hello from bar")
+
+    @cmdln.group("all")
+    def do_buz(self, argv):
+        "kaboom!"
+        print("hello from buz")
+
+    def _do_baz(self, argv):
+        "kazinga!"
+        print("hello from baz")
+
+    @cmdln.group("all", "foobar")
+    def do_fez(self, argv):
+        "pojoing!"
+        print("hello from fez")
+
+    @cmdln.group("foobar")
+    def do_buz(self, argv):
+        "buzzzzz!"
+        print("hello from buz")
+
+if __name__ == "__main__":
+    shell = Shell()
+    print(''.join(cmdln.man_sections_from_cmdln(shell, "jepajee")))


### PR DESCRIPTION
With these changes one can create additional help targets (e.g. "mytool help-all", "mytool help-expert", "mytool help-debug" etc.) so that if a tool has a plethora of subcommands they can be contextually divided into smaller groups. Not all subcommands necessarily target the same audience in which case it might also be convenient to divide commands for different user groups (hide advanced commands from beginners for example).

Should have no effect on old behaviour.

An usage example can been seen from the included new test.
